### PR TITLE
Fix issue #3: 投稿の削除機能を追加

### DIFF
--- a/src/components/blog/BlogList.tsx
+++ b/src/components/blog/BlogList.tsx
@@ -92,6 +92,17 @@ const BlogList = () => {
               <button type="button" className="read-more">
                 続きを読む
               </button>
+              <button
+                type="button"
+                className="delete-button"
+                onClick={() => {
+                  const updatedPosts = posts.filter(p => p.id !== post.id);
+                  setPosts(updatedPosts);
+                  localStorage.setItem('blogPosts', JSON.stringify(updatedPosts));
+                }}
+              >
+                削除
+              </button>
             </div>
           </article>
         ))}


### PR DESCRIPTION
This pull request fixes #3.

The PR added a delete button next to each blog entry in `BlogList.tsx`. The button's `onClick` handler filters out the deleted post from the `posts` state using `post.id`, updates the state with `setPosts`, and persists the change to `localStorage`. This directly implements the requested deletion functionality by modifying both the UI and data layer. No obvious flaws in the deletion logic are present in the provided patch.

Automatic fix generated by [OpenHands](https://github.com/All-Hands-AI/OpenHands/) 🙌