### PR TITLE
Fix issue #6: 投稿詳細表示画面の作成

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,0 +1,35 @@
+from flask import Flask, render_template, request, redirect, url_for
+app = Flask(__name__)
+
+# Temporary in-memory storage for demonstration
+posts = [
+    {'id': 1, 'title': 'First Post', 'content': 'This is my first post'},
+    {'id': 2, 'title': 'Second Post', 'content': 'Another interesting post'}
+]
+
+@app.route('/')
+def post_list():
+    return render_template('post_list.html', posts=posts)
+
+@app.route('/post/<int:post_id>')
+def post_detail(post_id):
+    post = next((p for p in posts if p['id'] == post_id), None)
+    if not post:
+        return "Post not found", 404
+    return render_template('post_detail.html', post=post)
+
+@app.route('/post/<int:post_id>/edit', methods=['GET', 'POST'])
+def edit_post(post_id):
+    post = next((p for p in posts if p['id'] == post_id), None)
+    if not post:
+        return "Post not found", 404
+
+    if request.method == 'POST':
+        post['title'] = request.form['title']
+        post['content'] = request.form['content']
+        return redirect(url_for('post_detail', post_id=post_id))
+
+    return render_template('edit_post.html', post=post)
+
+if __name__ == '__main__':
+    app.run(host='0.0.0.0', port=5000)

--- a/templates/edit_post.html
+++ b/templates/edit_post.html
@@ -1,0 +1,16 @@
+&lt;!DOCTYPE html&gt;
+&lt;html&gt;
+&lt;head&gt;
+    &lt;title&gt;Edit Post&lt;/title&gt;
+&lt;/head&gt;
+&lt;body&gt;
+    &lt;h1&gt;Edit Post&lt;/h1&gt;
+    &lt;form method=&quot;POST&quot;&gt;
+        &lt;label&gt;Title:&lt;/label&gt;
+        &lt;input type=&quot;text&quot; name=&quot;title&quot; value=&quot;{{ post.title }}&quot; required&gt;&lt;br&gt;
+        &lt;label&gt;Content:&lt;/label&gt;&lt;br&gt;
+        &lt;textarea name=&quot;content&quot; required&gt;{{ post.content }}&lt;/textarea&gt;&lt;br&gt;
+        &lt;button type=&quot;submit&quot;&gt;Save Changes&lt;/button&gt;
+    &lt;/form&gt;
+&lt;/body&gt;
+&lt;/html&gt;

--- a/templates/post_detail.html
+++ b/templates/post_detail.html
@@ -1,0 +1,12 @@
+&lt;!DOCTYPE html&gt;
+&lt;html&gt;
+&lt;head&gt;
+    &lt;title&gt;Post Detail&lt;/title&gt;
+&lt;/head&gt;
+&lt;body&gt;
+    &lt;a href="{{ url_for('post_list') }}"&gt;Back to List&lt;/a&gt;
+    &lt;h1&gt;{{ post.title }}&lt;/h1&gt;
+    &lt;p&gt;{{ post.content }}&lt;/p&gt;
+    &lt;a href="{{ url_for('edit_post', post_id=post.id) }}"&gt;Edit&lt;/a&gt;
+&lt;/body&gt;
+&lt;/html&gt;

--- a/templates/post_list.html
+++ b/templates/post_list.html
@@ -1,0 +1,18 @@
+&lt;!DOCTYPE html&gt;
+&lt;html&gt;
+&lt;head&gt;
+    &lt;title&gt;Post List&lt;/title&gt;
+&lt;/head&gt;
+&lt;body&gt;
+    &lt;h1&gt;Posts&lt;/h1&gt;
+    &lt;ul&gt;
+        {% for post in posts %}
+        &lt;li&gt;
+            &lt;a href="{{ url_for('post_detail', post_id=post.id) }}"&gt;
+                {{ post.title }}
+            &lt;/a&gt;
+        &lt;/li&gt;
+        {% endfor %}
+    &lt;/ul&gt;
+&lt;/body&gt;
+&lt;/html&gt;


### PR DESCRIPTION
This pull request fixes #6.

The changes implement both required functionalities. 

1. **Back Button**: `post_detail.html` includes a link to `post_list` using `url_for('post_list')`, enabling navigation back to the list view.

2. **Edit Functionality**: 
   - The `edit_post` route handles form submissions (POST) to update post data in memory.
   - `post_detail.html` links to `/post/<post_id>/edit`, and `edit_post.html` provides an editable form pre-filled with existing post data. 
   - Form submissions update the in-memory post data and redirect to the updated detail view.

All concrete requirements from the issue description are addressed in the code changes.

Automatic fix generated by [OpenHands](https://github.com/All-Hands-AI/OpenHands/) 🙌