### PR TITLE
Fix issue #9: 詳細画面の表示

### DIFF
--- a/src/components/blog/BlogList.tsx
+++ b/src/components/blog/BlogList.tsx
@@ -77,6 +77,12 @@ const BlogList = () => {
                                                </div>
 
                                                <p className="post-summary">{summarizeContent(post.content)}</p>
+                                               <div className="read-more">
+                                                   <Link to={`/blog/${post.id}`} className="read-more-link">
+                                                       続きを読む →
+                                                   </Link>
+                                               </div>
+
 
                                                {post.tags.length > 0 && (
                                                        <div className="post-tags">


### PR DESCRIPTION
This pull request fixes #9.

The AI agent added a `<Link>` component within each blog post entry in `BlogList.tsx`, setting the `to` prop to `/blog/${post.id}`. This creates navigable links using React Router's routing mechanism. The links are rendered immediately after each post summary with the "続きを読む" text. Assuming the application has an existing route configured for `/blog/:id` (implied by the context of a blog detail page requirement), this change directly implements the requested functionality of navigating to article details when clicking the button. No contradictory changes or implementation flaws are evident in the provided diff.

Automatic fix generated by [OpenHands](https://github.com/All-Hands-AI/OpenHands/) 🙌